### PR TITLE
Access color schemes through symbols

### DIFF
--- a/src/TextHeatmaps.jl
+++ b/src/TextHeatmaps.jl
@@ -3,7 +3,7 @@ module TextHeatmaps
 using Crayons: Crayon
 using FixedPointNumbers: N0f8
 using Colors: Colorant, RGB, hex
-using ColorSchemes: ColorScheme, get, seismic
+using ColorSchemes: ColorScheme, colorschemes, get, seismic
 
 include("heatmap.jl")
 

--- a/src/heatmap.jl
+++ b/src/heatmap.jl
@@ -8,7 +8,7 @@ Create a heatmap of words where the background color of each word is determined 
 Arguments `values` and `words` (and optionally `colors`) must have the same size.
 
 ## Keyword arguments
-- `colorscheme::ColorScheme`: color scheme from ColorSchemes.jl.
+- `colorscheme::Union{ColorScheme,Symbol}`: color scheme from ColorSchemes.jl.
   Defaults to `ColorSchemes.seismic`.
 - `rangescale::Symbol`: selects how the color channel reduced heatmap is normalized
   before the color scheme is applied. Can be either `:extrema` or `:centered`.
@@ -39,14 +39,18 @@ struct TextHeatmap{
 end
 
 function TextHeatmap(
-    val, words; colorscheme::ColorScheme=DEFAULT_COLORSCHEME, rangescale=DEFAULT_RANGESCALE
+    val, words; colorscheme::Union{ColorScheme,Symbol}=DEFAULT_COLORSCHEME, rangescale=DEFAULT_RANGESCALE
 )
     if size(val) != size(words)
         throw(ArgumentError("Sizes of values and words don't match"))
     end
+    colorscheme = get_colorscheme(colorscheme)
     colors = get(colorscheme, val, rangescale)
     return TextHeatmap(val, words, colors)
 end
+
+get_colorscheme(c::ColorScheme) = c
+get_colorscheme(s::Symbol)::ColorScheme = colorschemes[s]
 
 #==================#
 # Show in terminal #

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,13 @@ using Aqua
         h = heatmap(val, words; colorscheme=colorscheme, rangescale=:extrema)
         @test_reference "references/inferno_extrema.txt" repr("text/plain", h)
 
+        # Test colorscheme symbols
+        colorscheme = :inferno
+        h = heatmap(val, words; colorscheme=colorscheme, rangescale=:centered)
+        @test_reference "references/inferno_centered.txt" repr("text/plain", h)
+        h = heatmap(val, words; colorscheme=colorscheme, rangescale=:extrema)
+        @test_reference "references/inferno_extrema.txt" repr("text/plain", h)
+
         # Test errors
         @test_throws ArgumentError heatmap(val, ["Test", "Text", "Heatmaps"])
         # Test inner constructor


### PR DESCRIPTION
Instead of only supporting
```julia
heatmap(val, words; colorscheme=ColorSchemes.inferno)
```
color schemes can now also be accessed through their symbols:
```julia
heatmap(val, words; colorscheme=:inferno)
```